### PR TITLE
fix(client): remove file path from song name

### DIFF
--- a/client/src/components/SoundBar/SoundBar.components.tsx
+++ b/client/src/components/SoundBar/SoundBar.components.tsx
@@ -9,6 +9,7 @@ import { btnClickOne } from '../../audioControllers/buttonSounds';
 const SoundBar = (): JSX.Element => {
   const currentSongTitle = useAppSelector((state) => state.music.currentSong);
   const currentSong = musicController.findHowlFileFromTitle(currentSongTitle);
+  const titleToDisplay = currentSongTitle.split('media/')[1];
   const handleFocus = (e: React.FocusEvent<HTMLButtonElement>): void => {
     e.target.classList.add('sound-bar__btn--focus');
   };
@@ -82,7 +83,7 @@ const SoundBar = (): JSX.Element => {
           Next
         </button>
       </div>
-      <div className="sound-bar__song-title">🎵 {currentSongTitle} </div>
+      <div className="sound-bar__song-title">🎵 {titleToDisplay} </div>
       <MuteSoundBtn />
     </div>
   );


### PR DESCRIPTION
Hello,

First of all great job with the App! I'm a huge fun of the idea and also the execution is on point 👌

I was messing around and noticed there is a `/static/media/` prefix before the song name in the sound bar.

I'm not sure if this was intentionally a design choice: if so, feel fre to completely ignore my proposed change 🤣

Cheers 👋

Viktor